### PR TITLE
Included minimum Yara version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Twitter account: https://twitter.com/yararules
 
 Mail list : http://list.yararules.com/mailman/listinfo/yararules.com.signatures
 
+# Requirements
+
+Yara **version 3.0** or higher is required for most of the rules to work. This is mainly due to the use of the "pe" module introduced in that version.
+
+You can check your installed version with `yara -v`
+
+The available packages in Ubuntu 14.04 LTS default repositories are too old.  You can install from source or use the packages available in the [Remnux repository](https://launchpad.net/~remnux/+archive/ubuntu/stable).
+
 # Categories
 
 ## Antidebug/AntiVM


### PR DESCRIPTION
If you try to use the rules with Yara 2.x, you get a non-meaningful error:
malware/Android_Malware.yar(6): error: syntax error, unexpected _IDENTIFIER_, expecting $end or _RULE_ or _PRIVATE_ or _GLOBAL_