### PR TITLE
Fix syntax error in APT_threatgroup_3390.yar

### DIFF
--- a/malware/APT_threatgroup_3390.yar
+++ b/malware/APT_threatgroup_3390.yar
@@ -188,7 +188,7 @@ rule ThreatGroup3390_Strings {
 		$s4 = "c:\\temp\\ipcan.exe" fullword ascii
 		$s5 = "<%eval(Request.Item(\"admin-na-google123!@#" ascii
 	condition:
-		1 of them and filesize 30KB
+		1 of them and filesize < 30KB
 }
 
 rule ThreatGroup3390_C2 {


### PR DESCRIPTION
I think that Florian might have meant to say anything smaller than 30KB, but I'd check with mr.Roth to see if this was his intention, as I can't find the details on the filesizes in the report.