### PR TITLE
rename the second smsfraud rule to smsfraud_apk

### DIFF
--- a/Malware_Mobile/Android_malware_SMSsender.yar
+++ b/Malware_Mobile/Android_malware_SMSsender.yar
@@ -85,7 +85,7 @@ rule sms_fraud_gen : generic
 		androguard.permission(/android.permission.SEND_SMS/)
 }
 
-rule smsfraud
+rule smsfraud_apk
 {
 	meta:
 		author = "https://twitter.com/plutec_net"


### PR DESCRIPTION
This is to fix yara warning/exception about "duplicated identifier"