### PR TITLE
Update XOR_DDosv1

### DIFF
--- a/malware/XOR_DDosv1
+++ b/malware/XOR_DDosv1
@@ -1,16 +1,16 @@
 rule XOR_DDosv1 : DDoS
 {
   meta:
-    author = “Akamai SIRT”
-    description = “Rule to detect XOR DDos infection”
+    author = "Akamai SIRT"
+    description = "Rule to detect XOR DDos infection"
   strings:
-    $st0 = “BB2FA36AAA9541F0”
-    $st1 = “md5=”
-    $st2 = “denyip=”
-    $st3 = “filename=”
-    $st4 = “rmfile=”
-    $st5 = “exec_packet”
-    $st6 = “build_iphdr”
+    $st0 = "BB2FA36AAA9541F0"
+    $st1 = "md5="
+    $st2 = "denyip="
+    $st3 = "filename="
+    $st4 = "rmfile="
+    $st5 = "exec_packet"
+    $st6 = "build_iphdr"
   condition:
     all of them
 }


### PR DESCRIPTION
“ and ” will occur syntax error, they should be changed to ". 
XOR_DDosv1(4): syntax error, unexpected $end, expecting _NUMBER_ or _TEXT_STRING_ or _TRUE_ or _FALSE_