### PR TITLE
Fixing small error in Packer and Malware signature

### DIFF
--- a/Packers/packer.yar
+++ b/Packers/packer.yar
@@ -10993,22 +10993,6 @@ condition:
 		$a0
 }
 
-
-rule Install_Shield_2000
-{
-	meta:
-		author = "PEiD"
-		description = "Microsoft Visual C++ 5.0"
-		group = "15"
-		function = "16"
-	strings:
-		$a0 = { 55 8B EC 6A FF 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 64 A1 ?? ?? ?? ?? 50 64 89 25 ?? ?? ?? ?? 83 C4 ?? 53 56 57 }
-	condition:
-		$a0 at pe.entry_point
-}
-
-
-
 rule Obsidium1337ObsidiumSoftware
 {
       meta:

--- a/malware/APT_RedLeaves
+++ b/malware/APT_RedLeaves
@@ -17,9 +17,7 @@ rule malware_red_leaves_generic {
     $ = "\\\\.\\pipe\\NamePipe_MoreWindows" wide
     $ = "RedLeavesCMDSimulatorMutex" wide
     $ = "(NT %d.%d Build %d)" wide
-    $ = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; 
-      SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; 
-      .NET4.0E)" wide
+    $ = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)" wide
     $ = "red_autumnal_leaves_dllmain.dll" wide ascii
     $ = "__data" wide
     $ = "__serial" wide


### PR DESCRIPTION
The "Install_Shield_2000" signature appears twice in the Packer folder. Removing one, other wise Yara complains of duplicate signature. 

APT_RedLeaves file has carriage return for the UA that is causing errors. Made the string one line. 