### PR TITLE
Added Telefonica Ransomware rule

### DIFF
--- a/malware/RANSOM_Telefonica.yar
+++ b/malware/RANSOM_Telefonica.yar
@@ -4,7 +4,7 @@ rule ransom_telefonica : TELEF
 {
 	meta: 
 		author = "Joan Bono <@joan_bono>"
-		description = "Ransmoware Telefonica"
+		description = "Ransmoware Telefonica. WannaCry variant"
 		date = "2017-05-12"
 		reference = "http://www.elmundo.es/tecnologia/2017/05/12/59158a8ce5fdea194f8b4616.html"
 		md5 = "7f7ccaa16fb15eb1c7399d422f8363e8"

--- a/malware/RANSOM_Telefonica.yar
+++ b/malware/RANSOM_Telefonica.yar
@@ -1,0 +1,23 @@
+import "pe"
+
+rule ransom_telefonica : TELEF
+{
+	meta: 
+		author = "Joan Bono <@joan_bono>"
+		description = "Ransmoware Telefonica"
+		date = "2017-05-12"
+		reference = "http://www.elmundo.es/tecnologia/2017/05/12/59158a8ce5fdea194f8b4616.html"
+		md5 = "7f7ccaa16fb15eb1c7399d422f8363e8"
+		sha256 = "2584e1521065e45ec3c17767c065429038fc6291c091097ea8b22c8a502c41dd"
+	strings:	
+		$a = "115p7UMMngoj1pMvkpHijcRdfJNXj6LrLn" wide ascii nocase
+		$b = "12t9YDPgwueZ9NyMgw519p7AA8isjr6SMw" wide ascii nocase
+		$c = "13AM4VW2dhxYgXeQepoHkHSQuy6NgaEb94" wide ascii nocase
+		$d = "tasksche.exe"
+		$e = "RegCreateKeyW" wide ascii nocase
+		$f = "cmd.exe /c"
+	condition:
+		pe.characteristics and
+		for any of ($a, $b, $c, $d, $e, $f): (@ > @a)
+}
+


### PR DESCRIPTION
Added Telefonica Ransomware rule

News [here](http://www.elmundo.es/tecnologia/2017/05/12/59158a8ce5fdea194f8b4616.html) and [here](http://cincodias.elpais.com/cincodias/2017/05/12/companias/1494585502_908236.html)

~~~~
import "pe"

rule ransom_telefonica : TELEF
{
	meta:
		author = "Joan Bono <@joan_bono>"
		description = "Ransmoware Telefonica. WannaCry variant"
		date = "2017-05-12"
		reference = "http://www.elmundo.es/tecnologia/2017/05/12/59158a8ce5fdea194f8b4616.html"
		md5 = "7f7ccaa16fb15eb1c7399d422f8363e8"
		sha256 = "2584e1521065e45ec3c17767c065429038fc6291c091097ea8b22c8a502c41dd"
	strings:
		$a = "115p7UMMngoj1pMvkpHijcRdfJNXj6LrLn" wide ascii nocase
		$b = "12t9YDPgwueZ9NyMgw519p7AA8isjr6SMw" wide ascii nocase
		$c = "13AM4VW2dhxYgXeQepoHkHSQuy6NgaEb94" wide ascii nocase
		$d = "tasksche.exe"
		$e = "RegCreateKeyW" wide ascii nocase
		$f = "cmd.exe /c"
	condition:
		pe.characteristics and
		for any of ($a, $b, $c, $d, $e, $f): (@ > @a)
}
~~~~

