### PR TITLE
Worm Exploiting MS17-010 and dropping WannaCry Ransomware

### DIFF
--- a/malware/malw_ms17-010_wannacrypt.yar
+++ b/malware/malw_ms17-010_wannacrypt.yar
@@ -1,0 +1,26 @@
+/*
+    This Yara ruleset is under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html) and open to any user or organization, as    long as you use it under this license.
+
+*/
+
+import "pe"
+
+rule MS17_010_WanaCry_worm {
+	meta:
+		description = "Worm exploiting MS17-010 and dropping WannaCry Ransomware"
+		author = "Felipe Molina (@felmoltor)"
+		reference = "https://www.exploit-db.com/exploits/41987/"
+		date = "2017/05/12"
+	strings:
+		$ms17010_str1="PC NETWORK PROGRAM 1.0"
+		$ms17010_str2="LANMAN1.0"
+		$ms17010_str3="Windows for Workgroups 3.1a"
+		$ms17010_str4="__TREEID__PLACEHOLDER__"
+		$ms17010_str5="__USERID__PLACEHOLDER__"
+		$wannacry_payload_substr1 = "h6agLCqPqVyXi2VSQ8O6Yb9ijBX54j"
+		$wannacry_payload_substr2 = "h54WfF9cGigWFEx92bzmOd0UOaZlM"
+		$wannacry_payload_substr3 = "tpGFEoLOU6+5I78Toh/nHs/RAP"
+
+	condition:
+		all of them
+}


### PR DESCRIPTION
Sample of worm exploiting MS17-010 and dropping WannyCry ransomware that 12/05/2017 attacked Telefonica Spain and other companies around the globe.