### PR TITLE
Remove a too strict rule

### DIFF
--- a/malware/MALW_Magento_suspicious.yar
+++ b/malware/MALW_Magento_suspicious.yar
@@ -7,13 +7,6 @@ ref : https://github.com/gwillem/magento-malware-scanner/
 author : https://github.com/gwillem
 
 */
-global private rule malware_size {
-    meta:
-        description = "Limit on file size"
-    condition:
-        /* uint16(0) == 0x4B50 and filesize < 3MB */
-        filesize < 500KB
-}
 
 
 rule fromCharCode_in_unicode {


### PR DESCRIPTION
I'm new to Yara, so I may be missing something.

It seems that the global rule `malware_size` is too strict. Indeed some malware are bigger (Wannacry for example).
Maybe the use of [rules referencing ](http://yara.readthedocs.io/en/v3.5.0/writingrules.html#referencing-rules) is better suited for the `malware_size` rule ?