### PR TITLE
Add eml context to Yara-rules/email to avoid matching these for every file

### DIFF
--- a/email/attachment.yar
+++ b/email/attachment.yar
@@ -21,7 +21,14 @@ rule without_attachments : mail {
 		reference = "http://laboratorio.blogs.hispasec.com/"
 		description = "Rule to detect the no presence of any attachment"
 	strings:
+                $eml_01 = "From:"
+                $eml_02 = "To:"
+                $eml_03 = "Subject:"
 		$attachment_id = "X-Attachment-Id"
+                $mime_type = "Content-Type: multipart/mixed"
 	condition:
-		not $attachment_id
+                all of ( $eml_* ) and
+		not $attachment_id and 
+                not $mime_type
 }
+

--- a/email/image.yar
+++ b/email/image.yar
@@ -9,11 +9,15 @@ rule with_images : mail {
 		reference = "http://laboratorio.blogs.hispasec.com/"
 		description = "Rule to detect the presence of an or several images"
 	strings:
-		$a = ".jpg" nocase
-		$b = ".png" nocase
-		$c = ".bmp" nocase
+                $eml_01 = "From:"
+                $eml_02 = "To:"
+                $eml_03 = "Subject:"
+		$img_a = ".jpg" nocase
+		$img_b = ".png" nocase
+		$img_c = ".bmp" nocase
 	condition:
-		any of them
+                all of ( $eml_* ) and
+		any of ( $img_* )
 }
 
 rule without_images : mail {
@@ -22,9 +26,14 @@ rule without_images : mail {
 		reference = "http://laboratorio.blogs.hispasec.com/"
 		description = "Rule to detect the no presence of any image"
 	strings:
+                $eml_01 = "From:"
+                $eml_02 = "To:"
+                $eml_03 = "Subject:"
+
 		$a = ".jpg" nocase
 		$b = ".png" nocase
 		$c = ".bmp" nocase
 	condition:
+                all of ( $eml_* ) and
 		not $a and not $b and not $c
 }

--- a/email/urls.yar
+++ b/email/urls.yar
@@ -15,7 +15,6 @@ rule with_urls : mail {
 
 		$url_regex = /https?:\/\/([\w\.-]+)([\/\w \.-]*)/
 	condition:
-                all of ( $eml_* ) and
 		all of them
 }
 

--- a/email/urls.yar
+++ b/email/urls.yar
@@ -9,8 +9,13 @@ rule with_urls : mail {
 		reference = "http://laboratorio.blogs.hispasec.com/"
 		description = "Rule to detect the presence of an or several urls"
 	strings:
+                $eml_01 = "From:"
+                $eml_02 = "To:"
+                $eml_03 = "Subject:"
+
 		$url_regex = /https?:\/\/([\w\.-]+)([\/\w \.-]*)/
 	condition:
+                all of ( $eml_* ) and
 		all of them
 }
 
@@ -20,7 +25,12 @@ rule without_urls : mail {
 		reference = "http://laboratorio.blogs.hispasec.com/"
 		description = "Rule to detect the no presence of any url"
 	strings:
+                $eml_01 = "From:"
+                $eml_02 = "To:"
+                $eml_03 = "Subject:"
+
 		$url_regex = /https?:\/\/([\w\.-]+)([\/\w \.-]*)/
 	condition:
+                all of ( $eml_* ) and
 		not $url_regex
 }


### PR DESCRIPTION
Hello,
the yara rules in the Yara-rules/email are without context.
It is pretty annoying that these rules match for every single file with 3 rules with/without attachment/image/url even for files which are not email - like for executables.

I have tried to add also some other headers to match only eml files (or other files having the tags To: From: Subject:).

Please consider mergin in this change - thank you
Michal Ambroz