### PR TITLE
moving rule maldoc_OLE_file_magic_number to utils/magic.yar

### DIFF
--- a/Malicious_Documents/maldoc_somerules.yar
+++ b/Malicious_Documents/maldoc_somerules.yar
@@ -127,16 +127,6 @@ rule maldoc_getEIP_method_4 : maldoc
         any of them
 }
 
-rule maldoc_OLE_file_magic_number : maldoc
-{
-    meta:
-        author = "Didier Stevens (https://DidierStevens.com)"
-    strings:
-        $a = {D0 CF 11 E0}
-    condition:
-        $a
-}
-
 // 20150909 - Issue #39 - Commented because of High FP rate
 /*
 rule maldoc_suspicious_strings : maldoc

--- a/utils/magic.yar
+++ b/utils/magic.yar
@@ -1,0 +1,14 @@
+/*
+    This Yara ruleset is under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html) and open to any user or organization, as    long as you use it under this license.
+
+*/
+
+rule maldoc_OLE_file_magic_number : maldoc
+{
+    meta:
+        author = "Didier Stevens (https://DidierStevens.com)"
+    strings:
+        $a = {D0 CF 11 E0}
+    condition:
+        $a
+}


### PR DESCRIPTION
Hi,
The Malious_Documents/maldoc_somerules.yar file contains a rule named "maldoc_OLE_file_magic_number" that shouldn't be classified as malicious because it simply check if the file is a doc. This brings a lot of false positives and makes automation difficult.
So, i created a file "magic.yar" in utils which could handle all rules concerning magic and file types.

I hope you'll find this interesting.

