### PR TITLE
Create MALW_Miner_xmirg_generic.yar

### DIFF
--- a/malware/MALW_Miner_xmirg_generic.yar
+++ b/malware/MALW_Miner_xmirg_generic.yar
@@ -1,0 +1,8 @@
+
+rule xmrig
+{
+	strings:
+    $a1 = "stratum+tcp"
+    condition:
+    $a1  
+}


### PR DESCRIPTION
Detects "stratum+tcp", often used by malicious crypto-miners.
Reference: https://twitter.com/GelosSnake/status/935174138842566657 and https://gist.github.com/GelosSnake/c2d4d6ef6f93ccb7d3afb5b1e26c7b4e