### PR TITLE
Update Maldoc_PDF.yar

### DIFF
--- a/Malicious_Documents/Maldoc_PDF.yar
+++ b/Malicious_Documents/Maldoc_PDF.yar
@@ -305,7 +305,7 @@ rule multiple_versions : PDF raw
 		author = "Glenn Edwards (@hiddenillusion)"
 		version = "0.1"
         description = "Written very generically and doesn't hold any weight - just something that might be useful to know about to help show incremental updates to the file being analyzed"		
-		weight = 0
+		weight = 1
 		
         strings:
                 $magic = { 25 50 44 46 }


### PR DESCRIPTION
Change weight = 0 to 1 since 0 is not a valid weight for rule file. 
"Reason(3): Invalid weight for rule file."