### PR TITLE
Make is__elf private

### DIFF
--- a/malware/000_common_rules.yar
+++ b/malware/000_common_rules.yar
@@ -7,7 +7,7 @@
 	Rules that are included in several other files.
 */
 
-rule is__elf {
+private rule is__elf {
 	meta:
 		author = "@mmorenog,@yararules"
 	strings:


### PR DESCRIPTION
Make this rule private to prevent alerts for it as it only seems to serve as a building block for other rules.