### PR TITLE
Fix suspicious_packer_section rule

### DIFF
--- a/malware/MALW_PE_sections.yar
+++ b/malware/MALW_PE_sections.yar
@@ -82,5 +82,8 @@ rule suspicious_packer_section : packer PE {
         $s63 = "UPX!" wide ascii
 
     condition:
-        (uint16(0) == 0x457f and 1 of them)
+        // DOS stub signature                           PE signature
+        uint16(0) == 0x5a4d and uint32be(uint32(0x3c)) == 0x50450000 and (
+            for any of them : ( $ in (0..1024) )
+        )
 }


### PR DESCRIPTION
1. The check of first two bytes was wrong for PE files.
2. Limit the search to the first 1024 bytes of the files, which
   should be sufficient to match on section names.