### PR TITLE
fix syntax error MALW_ATM_HelloWorld.yar

### DIFF
--- a/malware/MALW_ATM_HelloWorld.yar
+++ b/malware/MALW_ATM_HelloWorld.yar
@@ -2,7 +2,7 @@
     This Yara ruleset is under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html) and open to any user or organization, as long as you use it under this license.
 */
 
-rule ATM_HelloWorld : 
+rule ATM_HelloWorld
 {
     meta:
         description = "Search strings and procedure in HelloWorld ATM Malware"


### PR DESCRIPTION
fix syntax error MALW_ATM_HelloWorld.yar: syntax error, unexpected '{', expecting identifier
![image](https://user-images.githubusercontent.com/526959/56953112-0c608880-6b66-11e9-8ba9-a855f043127c.png)