### PR TITLE
Add MALW_FUDCrypt.yar and MALW_MSILStealer.yar

### DIFF
--- a/malware/MALW_FUDCrypt.yar
+++ b/malware/MALW_FUDCrypt.yar
@@ -1,0 +1,25 @@
+rule FUDCrypter
+{
+    meta:
+        description = "Detects unmodified FUDCrypt samples"
+        reference = "https://github.com/gigajew/FudCrypt/"
+        author = "https://github.com/hwvs"
+        last_modified = "2019-11-21"
+
+    strings:
+        $ = "OcYjzPUtJkNbLOABqYvNbvhZf" wide ascii
+        $ = "gwiXxyIDDtoYzgMSRGMckRbJi" wide ascii
+        $ = "BclWgISTcaGjnwrzSCIuKruKm" wide ascii
+        $ = "CJyUSiUNrIVbgksjxpAMUkAJJ" wide ascii
+        $ = "fAMVdoPUEyHEWdxQIEJPRYbEN" wide ascii
+        $ = "CIGQUctdcUPqUjoucmcoffECY" wide ascii
+        $ = "wcZfHOgetgAExzSoWFJFQdAyO" wide ascii
+        $ = "DqYKDnIoLeZDWYlQWoxZnpfPR" wide ascii
+        $ = "MkhMoOHCbGUMqtnRDJKnBYnOj" wide ascii
+        $ = "sHEqLMGglkBAOIUfcSAgMvZfs" wide ascii
+        $ = "JtZApJhbFAIFxzHLjjyEQvtgd" wide ascii
+        $ = "IIQrSWZEMmoQIKGuxxwoTwXka" wide ascii
+
+    condition:
+        1 of them
+}

--- a/malware/MALW_FUDCrypt.yar
+++ b/malware/MALW_FUDCrypt.yar
@@ -1,3 +1,7 @@
+/*
+    This Yara ruleset is under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html) and open to any user or organization, as    long as you use it under this license.
+*/
+
 rule FUDCrypter
 {
     meta:

--- a/malware/MALW_MSILStealer.yar
+++ b/malware/MALW_MSILStealer.yar
@@ -1,0 +1,19 @@
+rule MSILStealer
+{
+    meta:
+        description = "Detects strings from C#/VB Stealers and QuasarRat"
+        reference = "https://github.com/quasar/QuasarRAT"
+        author = "https://github.com/hwvs"
+        last_modified = "2019-11-21"
+
+    strings:
+        $ = "Firefox does not have any profiles, has it ever been launched?" wide ascii
+        $ = "Firefox is not installed, or the install path could not be located" wide ascii
+        $ = "No installs of firefox recorded in its key." wide ascii
+        $ = "{0}\\\\FileZilla\\\\recentservers.xml" wide ascii
+        $ = "{1}{0}Cookie Name: {2}{0}Value: {3}{0}Path" wide ascii
+        $ = "[PRIVATE KEY LOCATION: \\\"{0}\\\"]" wide ascii
+
+    condition:
+        1 of them
+}

--- a/malware/MALW_MSILStealer.yar
+++ b/malware/MALW_MSILStealer.yar
@@ -1,3 +1,7 @@
+/*
+    This Yara ruleset is under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html) and open to any user or organization, as    long as you use it under this license.
+*/
+
 rule MSILStealer
 {
     meta:


### PR DESCRIPTION
FUDCrypt.yar:
Detects unmodified FUDCrypt stub samples

MALW_MSILStealer:
Detects some strings used in QuasarRAT, modified versions of QuasarRAT and some other .NET stealer samples using the same or related code.