### PR TITLE
Add Chacha stream cipher constants for 128-bit and 256-bit key

### DIFF
--- a/Crypto/crypto_signatures.yar
+++ b/Crypto/crypto_signatures.yar
@@ -1431,3 +1431,25 @@ rule DCP_DES_EncryptECB {
 	condition:
 		any of them
 }
+
+rule Chacha_128_constant {
+    meta:
+		author = "spelissier"
+		description = "Look for 128-bit key Chacha stream cipher constant"
+		date = "2019-12"
+	strings:
+		$c0 = "expand 16-byte k"
+	condition:
+		$c0
+}
+
+rule Chacha_256_constant {
+    meta:
+		author = "spelissier"
+		description = "Look for 256-bit key Chacha stream cipher constant"
+		date = "2019-12"
+	strings:
+		$c0 = "expand 32-byte k"
+	condition:
+		$c0
+}

--- a/Crypto/crypto_signatures.yar
+++ b/Crypto/crypto_signatures.yar
@@ -1437,6 +1437,7 @@ rule Chacha_128_constant {
 		author = "spelissier"
 		description = "Look for 128-bit key Chacha stream cipher constant"
 		date = "2019-12"
+		reference = "https://www.ecrypt.eu.org/stream/salsa20pf.html"
 	strings:
 		$c0 = "expand 16-byte k"
 	condition:
@@ -1448,6 +1449,7 @@ rule Chacha_256_constant {
 		author = "spelissier"
 		description = "Look for 256-bit key Chacha stream cipher constant"
 		date = "2019-12"
+		reference = "https://tools.ietf.org/html/rfc8439#page-8"
 	strings:
 		$c0 = "expand 32-byte k"
 	condition:


### PR DESCRIPTION
The constant for 256-bit key is defined in [RFC 8439](https://tools.ietf.org/html/rfc8439#page-8) and the constant for 128-bit key is defined in [Salsa specification](https://www.ecrypt.eu.org/stream/salsa20pf.html).