### PR TITLE
Renamed poetRAT to avoid dupes + adjusted criteria

### DIFF
--- a/malware/RAT_PoetRATDoc.yar
+++ b/malware/RAT_PoetRATDoc.yar
@@ -1,4 +1,4 @@
-rule PoetRat
+rule PoetRat_Doc
 {
     meta:
         Author = "Nishan Maharjan"

--- a/malware/RAT_PoetRATPython.yar
+++ b/malware/RAT_PoetRATPython.yar
@@ -1,4 +1,4 @@
-rule PoetRat
+rule PoetRat_Python
 {
     meta:
         Author = "Nishan Maharjan"
@@ -15,5 +15,5 @@ rule PoetRat
         $pipe_out = "Abibliophobia23"
         $shot = "shot_{0}_{1}.png"
     condition:
-    any of them        
+        3 of them        
 }


### PR DESCRIPTION
The regex for RAT_PoetRATPython was generating false positives. Adjusted
rule to need hits on at least 3 of the strings