### PR TITLE
change file type comment from exe to jar for JavaDropper : RAT

### DIFF
--- a/malware/MALW_Surtr.yar
+++ b/malware/MALW_Surtr.yar
@@ -5,7 +5,7 @@
 
 import "pe"
 
-rule RSharedStrings : Surtr Family {
+private rule RSharedStrings : Surtr Family {
 	meta:
 		description = "identifiers for remote and gmremote"
 		author = "Katie Kleemola"
@@ -24,7 +24,7 @@ rule RSharedStrings : Surtr Family {
 
 }
 
-rule RemoteStrings : Remote Variant Surtr Family {
+private rule RemoteStrings : Remote Variant Surtr Family {
 	meta:
 		description = "indicators for remote.dll - surtr stage 2"
 		author = "Katie Kleemola"
@@ -39,7 +39,7 @@ rule RemoteStrings : Remote Variant Surtr Family {
 		any of them
 }
 
-rule GmRemoteStrings : GmRemote Variant Family Surtr {
+private rule GmRemoteStrings : GmRemote Variant Family Surtr {
 	meta:
 		description = "identifiers for gmremote: surtr stage 2"
 		author = "Katie Kleemola"

--- a/malware/RAT_Ratdecoders.yar
+++ b/malware/RAT_Ratdecoders.yar
@@ -279,7 +279,7 @@ rule JavaDropper : RAT
 	    date = "2015/10"
 	    ref = "http://malwareconfig.com/stats/AlienSpy"
 	    maltype = "Remote Access Trojan"
-	    filetype = "exe"
+	    filetype = "jar"
 
     strings:
 	    $jar = "META-INF/MANIFEST.MF"


### PR DESCRIPTION
Rule appears to be written for a jar file and not exe