### PR TITLE
Stuxnet python rule

### DIFF
--- a/malware/APT_Stuxnet.yar
+++ b/malware/APT_Stuxnet.yar
@@ -197,3 +197,33 @@ rule Stuxnet_s7hkimdb
         ( uint16(0) == 0x5a4d and filesize < 40KB and $x1 and all of ($op*) )
 }
 
+rule Stuxnet_MadeInPython
+{
+    meta:
+        description = "Python has been used frequently by threat actors for compiling executable file with source code. I found python Stuxnet source code that can be executed with required dependencies. This rule is created in hopes to catch potental breakout of future Stuxnet."
+        author = "Jin Kim"
+        reference = "https://github.com/kenmueller/stuxnet"
+        date = "2020-12-23"
+    
+    strings:
+    // main function include this call stack as a second function call.
+        $str1 = "old_infected_attributes = node_infected_attributes(graph)"
+    //     def node_total_attributes(graph: nx.Graph) -> dict:
+	// filter_for_node_type = lambda node_type: list(filter(lambda node: get_node_type(graph, node) == node_type, graph.node))
+	// return {
+	// 	NodeType.COMPUTER: len(filter_for_node_type(NodeType.COMPUTER)),
+	// 	NodeType.DISCONNECTED_COMPUTER: len(filter_for_node_type(NodeType.DISCONNECTED_COMPUTER)),
+	// 	NodeType.USB: len(filter_for_node_type(NodeType.USB)),
+	// 	NodeType.PLC: len(filter_for_node_type(NodeType.PLC)),
+	// 	'total': len(graph.node)
+        $str2 = "NodeType.DISCONNECTED_COMPUTER"
+
+    // found in create-graph.py
+    // This line adds router nodes and computer nodes fro all the wireless networks.
+    // for router_node in range(NUMBER_OF_LOCAL_WIRED_NETWORKS, NUMBER_OF_LOCAL_NETWORKS):
+		// add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node)
+        $str3 = "add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node)"
+    
+    condition:
+        any of them
+}

--- a/malware/APT_Stuxnet.yar
+++ b/malware/APT_Stuxnet.yar
@@ -221,7 +221,7 @@ rule Stuxnet_MadeInPython
     // found in create-graph.py
     // This line adds router nodes and computer nodes fro all the wireless networks.
     // for router_node in range(NUMBER_OF_LOCAL_WIRED_NETWORKS, NUMBER_OF_LOCAL_NETWORKS):
-		// add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node)
+		// add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node) 
         $str3 = "add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node)"
     
     condition:

--- a/malware/APT_Stuxnet.yar
+++ b/malware/APT_Stuxnet.yar
@@ -221,7 +221,7 @@ rule Stuxnet_MadeInPython
     // found in create-graph.py
     // This line adds router nodes and computer nodes fro all the wireless networks.
     // for router_node in range(NUMBER_OF_LOCAL_WIRED_NETWORKS, NUMBER_OF_LOCAL_NETWORKS):
-		// add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node) 
+		// add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node)
         $str3 = "add_computer_nodes(graph, EdgeType.LOCAL_WIRELESS, router_node)"
     
     condition:


### PR DESCRIPTION
Python has been used frequently by threat actors for compiling executable file with source code. I found python Stuxnet source code that can be executed with required dependencies. This rule is created in hopes to catch potential breakout of future Stuxnet.