### PR TITLE
Tighten Glasses rule

### DIFF
--- a/malware/MALW_Glasses.yar
+++ b/malware/MALW_Glasses.yar
@@ -5,12 +5,15 @@
 
 import "pe"
 
-rule GlassesCode : Glasses Family 
+private rule GlassesCode : Glasses Family 
 {
     meta:
         description = "Glasses code features"
         author = "Seth Hardy"
-        last_modified = "2014-07-22"
+        last_modified = "2021-11-18"
+        reference_file = "aaf262fde1738dbf0bb50213a9624cd6705ebcaeb06c5fcaf7e9f33695d3fc33"
+        reference_url = "https://citizenlab.ca/2013/02/apt1s-glasses-watching-a-human-rights-organization/"
+
         
     strings:
         $ = { B8 AB AA AA AA F7 E1 D1 EA 8D 04 52 2B C8 }
@@ -25,7 +28,9 @@ rule GlassesStrings : Glasses Family
     meta:
         description = "Strings used by Glasses"
         author = "Seth Hardy"
-        last_modified = "2014-07-22"
+        last_modified = "2021-11-18"
+        reference_file = "aaf262fde1738dbf0bb50213a9624cd6705ebcaeb06c5fcaf7e9f33695d3fc33"
+        reference_url = "https://citizenlab.ca/2013/02/apt1s-glasses-watching-a-human-rights-organization/"
         
     strings:
         $ = "thequickbrownfxjmpsvalzydg"
@@ -42,9 +47,11 @@ rule Glasses : Family
     meta:
         description = "Glasses family"
         author = "Seth Hardy"
-        last_modified = "2014-07-22"
+        last_modified = "2021-11-18"
+        reference_file = "aaf262fde1738dbf0bb50213a9624cd6705ebcaeb06c5fcaf7e9f33695d3fc33"
+        reference_url = "https://citizenlab.ca/2013/02/apt1s-glasses-watching-a-human-rights-organization/"
    
     condition:
-        GlassesCode or GlassesStrings
+        GlassesCode and GlassesStrings
         
 }


### PR DESCRIPTION
Marked GlassesCode rule private to prevent alerting. Modified Glasses rule to require both GlassesCode and GlassesStrings to limit alerting. Added a reference URL and a reference file hash value to the rules. Updated the last modified dates. Tested rules against the reference hash file with both GlassesStrings and Glasses producing detections.

Fixes #422