### PR TITLE
Docs: Add missing description for 'utils' category to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ In this section you will find Yara rules specialised toward the identification o
 
 In this section you will find Yara rules specialised toward the identification of well-known mobile malware.
 
+## Utils
+
+In this section you will find Yara rules specialised toward the identification of common data patterns and generic forensic indicators. These rules serve as building blocks to detect network identifiers, file structures, or suspicious artifacts useful for broader analysis.
+
 ## Deprecated
 
 In this section you will find Yara rules deprecated.


### PR DESCRIPTION
Hello,

I noticed that the `utils` folder is present in the repository, containing files such as `ip.yar`, `url.yar`, `magic.yar` and `suspicious_strings.yar`, but it is currently missing from the **Categories** section in the `README.md`.

After analysing the contents, I have drafted a description to fill this gap, maintaining the existing style of the documentation.

**Changes:**
- Added a new **Utils** section to `README.md`.
- The description follows the existing style and summarises the utility of these rules as building blocks for broader analysis.

**Proposed text:**
> ## Utils
>
> In this section you will find Yara rules specialised toward the identification of common data patterns and generic forensic indicators. These rules serve as building blocks to detect network identifiers, file structures, or suspicious artifacts useful for broader analysis.

I hope this contribution helps improve the project's documentation.